### PR TITLE
Expose the response to components

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const handleRequest = (App, opts) => async (req, res) => {
   if (opts.svg) res.setHeader('Content-Type', 'image/svg+xml')
   if (!opts.raw && !opts.noWrap) res.write(header)
   if (!opts.noWrap) res.write('<div id=div>')
-  const props = Object.assign({}, opts, { req })
+  const props = Object.assign({}, opts, { req, res })
 
   delete props.script
 


### PR DESCRIPTION
By exposing the response itself, a component
can do fancy things like setting headers.