### PR TITLE
Remove svg specific options

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,6 @@ const cli = meow(`
     --raw, -r      Serve raw output with no doctype declaration
     --bundle, -b   Render with bundled javascript
     --noWrap, -n   Opt out of wrapping component in a div
-    --svg, -g      Set content-type to image/svg+xml
 `, {
   flags: {
     port: {
@@ -36,11 +35,6 @@ const cli = meow(`
       type: 'boolean',
       default: false,
       alias: 'n'
-    },
-    svg: {
-      type: 'boolean',
-      default: false,
-      alias: 'g'
     }
   }
 })

--- a/docs/Icon.js
+++ b/docs/Icon.js
@@ -1,13 +1,18 @@
 const React = require('react')
 
-const Icon = props =>
-  <svg
-    xmlns='http://www.w3.org/2000/svg'
-    viewBox='0 0 32 32'
-    fill={props.fill}
-  >
-    <path d="M16 0 C6 0 2 4 2 14 L2 22 L6 24 L6 30 L26 30 L26 24 L30 22 L30 14 C30 4 26 0 16 0 M9 12 A4.5 4.5 0 0 1 9 21 A4.5 4.5 0 0 1 9 12 M23 12 A4.5 4.5 0 0 1 23 21 A4.5 4.5 0 0 1 23 12"/>
-  </svg>
+const Icon = props => {
+  props.res.setHeader('Content-Type', 'image/svg+xml')
+
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 32 32'
+      fill={props.fill}
+    >
+      <path d="M16 0 C6 0 2 4 2 14 L2 22 L6 24 L6 30 L26 30 L26 24 L30 22 L30 14 C30 4 26 0 16 0 M9 12 A4.5 4.5 0 0 1 9 21 A4.5 4.5 0 0 1 9 12 M23 12 A4.5 4.5 0 0 1 23 21 A4.5 4.5 0 0 1 23 12"/>
+    </svg>
+  )
+}
 
 Icon.defaultProps = {
   fill: 'currentColor'

--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ const start = async (opts) => {
 }
 
 const handleRequest = (App, opts) => async (req, res) => {
-  if (opts.svg) res.setHeader('Content-Type', 'image/svg+xml')
   if (!opts.raw && !opts.noWrap) res.write(header)
   if (!opts.noWrap) res.write('<div id=div>')
   const props = Object.assign({}, opts, { req, res })

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "styled": "./cli.js docs/StyledComponents.js",
     "nano": "./cli.js docs/Nano.js",
     "bundle": "./cli.js docs/Bundle.js --bundle",
-    "icon": "./cli.js docs/Icon.js -ng"
+    "icon": "./cli.js docs/Icon.js -n"
   },
   "keywords": [],
   "author": "Brent Jackson",


### PR DESCRIPTION
Since the response object is passed
to the component we can keep the api
simpler by having components handle
setting specific headers.